### PR TITLE
Add timestamp to total fees burned

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -267,6 +267,9 @@ function TotalFeesCard(props: TotalFeesCardProps) {
           )
         })}
       </HStack>
+      <Box fontSize="14px" mt="0" color="brand.secondaryText">
+          since {timeSince(1624500217)}
+      </Box>
     </Card>
   )
 }


### PR DESCRIPTION
Added a timestamp since EIP 1559 at the bottom of the "Total Fees Burned" section.
Timestamp determined by timestamp of block 10499401 (Jun-24-2021 02:03:37 AM +UTC).
Source: ​https://ropsten.etherscan.io/block/10499401