### PR TITLE
stop caching null responses from geth and enhance log messages

### DIFF
--- a/cache/entrypoint.sh
+++ b/cache/entrypoint.sh
@@ -25,4 +25,4 @@ trap 'kill ${!}; term_handler' SIGTERM
 sed -i "s/localhost/${GETH_HTTP_HOST}/g" /etc/varnish/default.vcl
 sed -i "s/8545/${GETH_HTTP_PORT}/g" /etc/varnish/default.vcl
 
-exec varnishd -a :${VARNISH_PORT} -f /etc/varnish/default.vcl -s ${CACHE_TYPE},${CACHE_SIZE} -p nuke_limit=9999999 -F & varnishncsa -F "%{%H:%M:%S}t - %U - %{X-Custom-Method}i - %{Varnish:hitmiss}x - %D usec - %O bytes" #tail -f /dev/null 
+exec varnishd -a :${VARNISH_PORT} -f /etc/varnish/default.vcl -s ${CACHE_TYPE},${CACHE_SIZE} -p nuke_limit=9999999 -F & varnishncsa -F "%{%H:%M:%S}t - %U - %{X-Custom-Method}i - %{X-Custom-Block-Number}i - %{Varnish:hitmiss}x - %D usec - %O bytes" #tail -f /dev/null 


### PR DESCRIPTION
stop caching null responses for `eth_getBlockByNumber`, `eth_getUncleByBlockNumberAndIndex `, and `eth_getTransactionReceipt`

bypass cache on `eth_blockNumber`

log block number when header `X-Custom-Block-Number` is provided