### PR TITLE
daemon: Add initial data support

### DIFF
--- a/daemon/hub/latestblocks.go
+++ b/daemon/hub/latestblocks.go
@@ -1,0 +1,40 @@
+package hub
+
+import (
+	"sync"
+
+	"github.com/mohamedmansour/ethereum-burn-stats/daemon/sql"
+)
+
+// LatestBlocks defines a mutexed list of latest blocks
+type LatestBlocks struct {
+	blocks    []sql.BlockStats
+	mu        sync.Mutex
+	maxBlocks int
+}
+
+func newLatestBlocks(maxBlocks int) *LatestBlocks {
+	return &LatestBlocks{
+		blocks: []sql.BlockStats{},
+		maxBlocks: maxBlocks,
+	}
+}
+
+func (lb *LatestBlocks) getBlocks() []sql.BlockStats {
+	lb.mu.Lock()
+	defer lb.mu.Unlock()
+
+	return lb.blocks
+}
+
+func (lb *LatestBlocks) addBlock(block sql.BlockStats) {
+	lb.mu.Lock()
+	defer lb.mu.Unlock()
+
+	sliceEnd := lb.maxBlocks
+	if len(lb.blocks) < lb.maxBlocks {
+		sliceEnd = len(lb.blocks) + 1
+	}
+
+	lb.blocks = append([]sql.BlockStats{block}, lb.blocks...)[:sliceEnd]
+}

--- a/daemon/hub/types.go
+++ b/daemon/hub/types.go
@@ -27,32 +27,35 @@ type Block struct {
 	Uncles           []interface{} `json:"uncles"`
 }
 
+// TransactionLog type represents the transaction log.
+type TransactionLog struct {
+	Address          string   `json:"address"`
+	Topics           []string `json:"topics"`
+	Data             string   `json:"data"`
+	BlockNumber      string   `json:"blockNumber"`
+	TransactionHash  string   `json:"transactionHash"`
+	TransactionIndex string   `json:"transactionIndex"`
+	BlockHash        string   `json:"blockHash"`
+	LogIndex         string   `json:"logIndex"`
+	Removed          bool     `json:"removed"`
+}
+
 // TransactionReceipt type represents a single ethereum Transaction.
 type TransactionReceipt struct {
-	BlockHash         string      `json:"blockHash"`
-	BlockNumber       string      `json:"blockNumber"`
-	ContractAddress   interface{} `json:"contractAddress"`
-	CumulativeGasUsed string      `json:"cumulativeGasUsed"`
-	EffectiveGasPrice string      `json:"effectiveGasPrice"`
-	From              string      `json:"from"`
-	GasUsed           string      `json:"gasUsed"`
-	Logs              []struct {
-		Address          string   `json:"address"`
-		Topics           []string `json:"topics"`
-		Data             string   `json:"data"`
-		BlockNumber      string   `json:"blockNumber"`
-		TransactionHash  string   `json:"transactionHash"`
-		TransactionIndex string   `json:"transactionIndex"`
-		BlockHash        string   `json:"blockHash"`
-		LogIndex         string   `json:"logIndex"`
-		Removed          bool     `json:"removed"`
-	} `json:"logs"`
-	LogsBloom        string `json:"logsBloom"`
-	Status           string `json:"status"`
-	To               string `json:"to"`
-	TransactionHash  string `json:"transactionHash"`
-	TransactionIndex string `json:"transactionIndex"`
-	Type             string `json:"type"`
+	BlockHash         string           `json:"blockHash"`
+	BlockNumber       string           `json:"blockNumber"`
+	ContractAddress   interface{}      `json:"contractAddress"`
+	CumulativeGasUsed string           `json:"cumulativeGasUsed"`
+	EffectiveGasPrice string           `json:"effectiveGasPrice"`
+	From              string           `json:"from"`
+	GasUsed           string           `json:"gasUsed"`
+	Logs              []TransactionLog `json:"logs"`
+	LogsBloom         string           `json:"logsBloom"`
+	Status            string           `json:"status"`
+	To                string           `json:"to"`
+	TransactionHash   string           `json:"transactionHash"`
+	TransactionIndex  string           `json:"transactionIndex"`
+	Type              string           `json:"type"`
 }
 
 // Totals type represents a single aggregate of all the data.
@@ -62,9 +65,17 @@ type Totals struct {
 	Issuance string `json:"issuance"`
 }
 
-// BlockData type represents a new block event.
-type Data struct {
-	BlockStats sql.BlockStats `json:"stats"`
-	Clients    int16          `json:"clients"`
-	Totals     Totals         `json:"totals"`
+// InitialData type represents the initial data that the client requests.
+type InitialData struct {
+	Blocks            []sql.BlockStats `json:"blocks"`
+	Clients           int16            `json:"clients"`
+	Totals            Totals           `json:"totals"`
+	BlockNumber       uint64           `json:"blockNumber"`
+}
+
+// ClientData type represents the data that the server sends at every new block.
+type BlockData struct {
+	Block      sql.BlockStats   `json:"block"`
+	Clients    int16            `json:"clients"`
+	Totals     Totals           `json:"totals"`
 }

--- a/daemon/hub/types.go
+++ b/daemon/hub/types.go
@@ -1,5 +1,7 @@
 package hub
 
+import "github.com/mohamedmansour/ethereum-burn-stats/daemon/sql"
+
 // Block type represents a single ethereum Block.
 type Block struct {
 	BaseFeePerGas    string        `json:"baseFeePerGas"`
@@ -51,4 +53,18 @@ type TransactionReceipt struct {
 	TransactionHash  string `json:"transactionHash"`
 	TransactionIndex string `json:"transactionIndex"`
 	Type             string `json:"type"`
+}
+
+// Totals type represents a single aggregate of all the data.
+type Totals struct {
+	Burned   string `json:"burned"`
+	Tipped   string `json:"tipped"`
+	Issuance string `json:"issuance"`
+}
+
+// BlockData type represents a new block event.
+type Data struct {
+	BlockStats sql.BlockStats `json:"stats"`
+	Clients    int16          `json:"clients"`
+	Totals     Totals         `json:"totals"`
 }

--- a/daemon/sql/database.go
+++ b/daemon/sql/database.go
@@ -26,10 +26,14 @@ func ConnectDatabase(dbPath string) (*Database, error) {
 
 	if !db.Migrator().HasTable(&BlockStats{}) {
 		db.Migrator().CreateTable(&BlockStats{})
+	} else {
+		db.Migrator().AutoMigrate(BlockStats{})
 	}
 
 	if !db.Migrator().HasTable(&BlockStatsPercentiles{}) {
 		db.Migrator().CreateTable(&BlockStatsPercentiles{})
+	} else {
+		db.Migrator().AutoMigrate(BlockStats{})
 	}
 
 	return &Database{

--- a/frontend/src/contexts/BlockExplorerContext.tsx
+++ b/frontend/src/contexts/BlockExplorerContext.tsx
@@ -4,12 +4,12 @@ import { BigNumber } from 'ethers'
 import { useSetting } from "../hooks/useSetting";
 import { Loader } from "../organisms/Loader";
 import { useReducer } from "react";
-import { prefetchCount, Setting } from "../config";
+import { Setting } from "../config";
 import { BigNumberMax, BigNumberMin, Zero } from "../utils/number";
-import { Block, BlockStats, EthereumApi } from "../libs/ethereum";
+import { BlockData, BlockStats, BlockWithTransactions, Totals } from "../libs/ethereum";
 
-export interface BurnedBlockTransaction extends Block {
-  stats: BlockStats
+export interface BurnedBlockTransaction extends BlockWithTransactions {
+  stats?: BlockStats
 }
 
 export interface BlockExplorerSession {
@@ -23,27 +23,21 @@ export interface BlockExplorerSession {
 }
 
 export interface BlockExplorerDetails {
-  totalBurned: BigNumber
-  totalTipped: BigNumber
+  totals: Totals
   currentBlock: number
   currentBaseFee: BigNumber
+  clients: number
 }
 
 type BlockExplorerContextType = {
   details?: BlockExplorerDetails
   blocks?: BlockStats[]
   session?: BlockExplorerSession
-  clients?: number
 }
 
-interface NewClientsAction {
-  type: 'NEW_CLIENTS'
-  count: number
-}
-
-interface NewBlockAction {
-  type: 'NEW_BLOCK'
-  block: BlockStats
+interface NewDataAction {
+  type: 'NEW_DATA'
+  data: BlockData
   maxBlocksToRender: number
 }
 
@@ -54,24 +48,8 @@ interface InitAction {
 }
 
 type ActionType =
-  | NewClientsAction
-  | NewBlockAction
+  | NewDataAction
   | InitAction
-
-export const BlockExplorerApi = {
-  fetchBlock: async (eth: EthereumApi, blockNumber: number): Promise<BurnedBlockTransaction | undefined> => {
-    const block = await eth.getBlock(blockNumber) as BurnedBlockTransaction
-    if (block) {
-      const blockStats = await eth.getBlockStats(block.number)
-      if (blockStats) {
-        block.stats = blockStats
-      }
-      return block
-    }
-
-    return undefined
-  }
-}
 
 const BlockExplorerContext = createContext<BlockExplorerContextType>({
   details: undefined,
@@ -82,36 +60,34 @@ const useBlockExplorer = () => useContext(BlockExplorerContext);
 
 const blockExplorerReducer = (state: BlockExplorerContextType, action: ActionType): BlockExplorerContextType => {
   switch (action.type) {
-    case 'NEW_CLIENTS': {
-      return { ...state, clients: action.count };
-    }
-    case 'NEW_BLOCK': {
-      if (!state.details || !action.block || !state.session)
+    case 'NEW_DATA': {
+      if (!state.details || !state.session)
         return state
 
-      let totalBurned = state.details.totalBurned
-      if (!action.block.burned.isZero()) {
-        totalBurned = action.block.burned.add(totalBurned)
-        state.session.burned = state.session.burned.add(action.block.burned)
+      const { block, totals, clients } = action.data
+
+      if (!block.burned.isZero()) {
+        state.session.burned = state.session.burned.add(block.burned)
       }
 
-      let totalTipped = state.details.totalTipped
-      if (!action.block.tips.isZero()) {
-        totalTipped = action.block.tips.add(totalTipped)
-        state.session.tips = state.session.tips.add(action.block.tips)
+      if (!block.tips.isZero()) {
+        state.session.tips = state.session.tips.add(block.tips)
       }
 
-      state.details.currentBaseFee = action.block.baseFee
-      state.details.currentBlock = action.block.number
-      state.session.rewards = state.session.rewards.add(action.block.rewards)
+      if (!block.rewards.isZero()) {
+        state.session.rewards = state.session.rewards.add(block.rewards)
+      }
+
+      state.details.currentBaseFee = block.baseFee
+      state.details.currentBlock = block.number
       state.session.blockCount = state.session.blockCount + 1
-      state.session.transactionCount = state.session.transactionCount + action.block.transactions
-      state.session.minBaseFee = BigNumberMin(action.block.baseFee, state.session.minBaseFee)
-      state.session.maxBaseFee = BigNumberMax(action.block.baseFee, state.session.maxBaseFee)
+      state.session.transactionCount = state.session.transactionCount + block.transactions
+      state.session.minBaseFee = BigNumberMin(block.baseFee, state.session.minBaseFee)
+      state.session.maxBaseFee = BigNumberMax(block.baseFee, state.session.maxBaseFee)
 
       const newState: BlockExplorerContextType = {
-        details: { ...state.details, totalBurned, totalTipped },
-        blocks: [action.block, ...((state.blocks || []).slice(0, action.maxBlocksToRender - 1))],
+        details: { ...state.details, totals, clients },
+        blocks: [block, ...((state.blocks || []).slice(0, action.maxBlocksToRender - 1))],
         session: state.session
       }
 
@@ -159,70 +135,39 @@ const BlockExplorerProvider = ({
     if (!eth)
       return
 
-    const onClient = (count: number) => {
+    const onNewData = async (data: BlockData) => {
       dispatch({
-        type: 'NEW_CLIENTS',
-        count
-      })
-    };
-
-    const onNewBlockHeader = async (block: BlockStats) => {
-      dispatch({
-        type: 'NEW_BLOCK',
-        block,
+        type: 'NEW_DATA',
+        data,
         maxBlocksToRender
       })
     }
 
-    const prefetchBlockHeaders = async (blockHeaderCount: number): Promise<[number, BlockStats[]]> => {
-      const latestBlockNumber = (process.env.REACT_APP_START_BLOCK ? parseInt(process.env.REACT_APP_START_BLOCK) : await eth.getBlockNumber())
-
-      const processedBlocks: BlockStats[] = []
-      
-      for (var i = 0; i < blockHeaderCount; i++) {
-        const blockNumber = Math.max(0, latestBlockNumber - i)
-        const block = await eth.getBlockStats(blockNumber)
-        if (block)
-          processedBlocks.push(block)
-      }
-
-      return [latestBlockNumber, processedBlocks]
-    }
-
     const init = async () => {
-      const totals = await eth.getTotals()
-      const [latestBlockNumber, blocks] = await prefetchBlockHeaders(prefetchCount)
-
-      if (blocks.length) {
-        const block = blocks[0]
-        const details = {
-          currentBlock: block.number,
-          totalBurned: totals.burned,
-          totalTipped: totals.tipped,
-          currentBaseFee: block.baseFee
-        }
-        dispatch({ type: 'INIT', details, blocks })
-      } else {
-        dispatch({
-          type: 'INIT',
-          details: {
-            currentBlock: latestBlockNumber,
-            totalBurned: totals.burned,
-            totalTipped: totals.tipped,
-            currentBaseFee: Zero()
-          }, blocks: []
-        })
+      const initialData = await eth.getInitialData()
+      
+      let currentBaseFee = Zero()
+      if (initialData.blocks.length) {
+        const block = initialData.blocks[0]
+        currentBaseFee = block.baseFee
+      } 
+      
+      const details: BlockExplorerDetails = {
+        currentBlock: initialData.blockNumber,
+        currentBaseFee: currentBaseFee,
+        totals: initialData.totals,
+        clients: initialData.clients
       }
 
-      eth.on('block', onNewBlockHeader)
-      eth.on('client', onClient)
+      dispatch({ type: 'INIT', details, blocks: initialData.blocks })
+
+      eth.on('data', onNewData)
     }
 
     init()
 
     return () => {
-      eth.off('block', onNewBlockHeader)
-      eth.off('client', onClient)
+      eth.off('data', onNewData)
     }
   }, [eth, maxBlocksToRender])
 

--- a/frontend/src/contexts/BlockExplorerContext.tsx
+++ b/frontend/src/contexts/BlockExplorerContext.tsx
@@ -95,7 +95,7 @@ const blockExplorerReducer = (state: BlockExplorerContextType, action: ActionTyp
     }
     case 'INIT': {
       const session: BlockExplorerSession = {
-        blockCount: action.blocks.length,
+        blockCount: 0,
         burned: Zero(),
         rewards: Zero(),
         tips: Zero(),
@@ -103,17 +103,6 @@ const blockExplorerReducer = (state: BlockExplorerContextType, action: ActionTyp
         minBaseFee: BigNumber.from(Number.MAX_SAFE_INTEGER.toString()),
         maxBaseFee: BigNumber.from(Number.MIN_SAFE_INTEGER.toString()),
       }
-
-      action.blocks.map(block => {
-        const basefee = block.baseFee
-        session.transactionCount += block.transactions
-        session.burned = block.burned.add(session.burned)
-        session.rewards = block.rewards.add(session.rewards)
-        session.minBaseFee = BigNumberMin(basefee, session.minBaseFee)
-        session.maxBaseFee = BigNumberMax(basefee, session.maxBaseFee)
-
-        return block;
-      })
 
       return { blocks: action.blocks, details: action.details, session }
     }

--- a/frontend/src/libs/ethereum/ethereum-api-formatters.ts
+++ b/frontend/src/libs/ethereum/ethereum-api-formatters.ts
@@ -1,5 +1,5 @@
 import { HexToBigNumber, HexToNumber } from "../../utils/number"
-import { BaseBlock, BlockStats, BlockWithTransactions, Data, EthereumSyncing, Totals, Transaction } from "./ethereum-types"
+import { BaseBlock, BlockData, BlockStats, BlockWithTransactions, EthereumSyncing, InitialData, Totals, Transaction } from "./ethereum-types"
 
 export class EthereumApiFormatters {
   static FormatTransaction(t: Transaction): Transaction {
@@ -68,12 +68,16 @@ export class EthereumApiFormatters {
     return s
   }
 
-  static FormatData(d: Data): Data {
-    console.log(d);
-    const blockStats = this.FormatBlockStats(d.blockStats)
-    if (blockStats)
-      d.blockStats = blockStats
+  static FormatInitialData(d: InitialData): InitialData {
+    d.blocks = d.blocks ? d.blocks.map(b => this.FormatBlockStats(b)!) : []
     d.totals = this.FormatTotals(d.totals)
+    d.blockNumber = HexToNumber(d.blockNumber)
     return d
+  }
+  
+  static FormatBlockData(b: BlockData): BlockData {
+    b.block = this.FormatBlockStats(b.block)!
+    b.totals = this.FormatTotals(b.totals)
+    return b
   }
 }

--- a/frontend/src/libs/ethereum/ethereum-api-formatters.ts
+++ b/frontend/src/libs/ethereum/ethereum-api-formatters.ts
@@ -1,5 +1,5 @@
 import { HexToBigNumber, HexToNumber } from "../../utils/number"
-import { BaseBlock, BlockStats, BlockWithTransactions, EthereumSyncing, Totals, Transaction } from "./ethereum-types"
+import { BaseBlock, BlockStats, BlockWithTransactions, Data, EthereumSyncing, Totals, Transaction } from "./ethereum-types"
 
 export class EthereumApiFormatters {
   static FormatTransaction(t: Transaction): Transaction {
@@ -66,5 +66,14 @@ export class EthereumApiFormatters {
     s.burned = HexToBigNumber(s.burned)
     s.tipped = HexToBigNumber(s.tipped)
     return s
+  }
+
+  static FormatData(d: Data): Data {
+    console.log(d);
+    const blockStats = this.FormatBlockStats(d.blockStats)
+    if (blockStats)
+      d.blockStats = blockStats
+    d.totals = this.FormatTotals(d.totals)
+    return d
   }
 }

--- a/frontend/src/libs/ethereum/ethereum-api.ts
+++ b/frontend/src/libs/ethereum/ethereum-api.ts
@@ -3,11 +3,12 @@ import { EthereumNetwork } from "../../config";
 import { HexToBigNumber, HexToNumber } from "../../utils/number";
 import { WebSocketProvider, WebSocketEventMap } from "./websocket-provider";
 import { EthereumApiFormatters } from "./ethereum-api-formatters";
-import { Block, BlockStats, BlockWithTransactions, EthereumSyncing, Totals, Transaction } from "./ethereum-types";
+import { Block, BlockStats, BlockWithTransactions, Data, EthereumSyncing, Totals, Transaction } from "./ethereum-types";
 
 interface EthereumWebSocketEventMap extends WebSocketEventMap {
   "block": BlockStats
   "client": number
+  "data": Data
 }
 
 /**
@@ -23,6 +24,7 @@ export class EthereumApi extends WebSocketProvider<EthereumWebSocketEventMap> {
     super(url, maxReconnectionAttempts, [
       { channel: 'blockStats', event: 'block', formatter: (b: any) => EthereumApiFormatters.FormatBlockStats(b) },
       { channel: 'clientsCount', event: 'client' },
+      { channel: 'data', event: 'data', formatter: (d: any) => EthereumApiFormatters.FormatData(d) },
     ])
   }
 

--- a/frontend/src/libs/ethereum/ethereum-api.ts
+++ b/frontend/src/libs/ethereum/ethereum-api.ts
@@ -1,14 +1,14 @@
 import { BigNumber, utils } from "ethers";
 import { EthereumNetwork } from "../../config";
-import { HexToBigNumber, HexToNumber } from "../../utils/number";
+import { HexToBigNumber } from "../../utils/number";
 import { WebSocketProvider, WebSocketEventMap } from "./websocket-provider";
 import { EthereumApiFormatters } from "./ethereum-api-formatters";
-import { Block, BlockStats, BlockWithTransactions, Data, EthereumSyncing, Totals, Transaction } from "./ethereum-types";
+import { BlockData, BlockStats, BlockWithTransactions, EthereumSyncing, InitialData,  Transaction } from "./ethereum-types";
 
 interface EthereumWebSocketEventMap extends WebSocketEventMap {
   "block": BlockStats
   "client": number
-  "data": Data
+  "data": BlockData
 }
 
 /**
@@ -24,7 +24,7 @@ export class EthereumApi extends WebSocketProvider<EthereumWebSocketEventMap> {
     super(url, maxReconnectionAttempts, [
       { channel: 'blockStats', event: 'block', formatter: (b: any) => EthereumApiFormatters.FormatBlockStats(b) },
       { channel: 'clientsCount', event: 'client' },
-      { channel: 'data', event: 'data', formatter: (d: any) => EthereumApiFormatters.FormatData(d) },
+      { channel: 'data', event: 'data', formatter: (d: any) => EthereumApiFormatters.FormatBlockData(d) },
     ])
   }
 
@@ -32,41 +32,9 @@ export class EthereumApi extends WebSocketProvider<EthereumWebSocketEventMap> {
     return EthereumApiFormatters.FormatSync(await this.send('eth_syncing', []))
   }
 
-  public async getTotals(): Promise<Totals> {
-    const key = `${this.connectedNetwork.chainId}getTotals()`
-    const result = await this.cachedExecutor<Totals>(key, () => this.send('internal_getTotals', []))
-    return EthereumApiFormatters.FormatTotals(result)
-  }
-
-  public async getBlockNumber(): Promise<number> {
-    const key = `${this.connectedNetwork.chainId}getBlockNumber()`
-    const result = await this.cachedExecutor(key, () => this.send('eth_blockNumber', []), 10000)
-    return HexToNumber(result);
-  }
-
-  public async getBlock(blockNumber: number): Promise<Block> {
-    if (blockNumber < 0)
-      throw Error(`Invalid block of negative value ${blockNumber}`)
-
-    const blockNumberInHex = utils.hexValue(blockNumber)
-    const key = `${this.connectedNetwork.chainId}getBlock(${blockNumberInHex})`
-    const result = await this.cachedExecutor<Block>(key, () => this.send('eth_getBlockByNumber', [blockNumberInHex, false]))
-    return EthereumApiFormatters.FormatBlock(result) as Block
-  }
-
-  public async getBlockStats(blockNumber: number): Promise<BlockStats | undefined> {
-    if (blockNumber < 0)
-      throw Error(`Invalid block of negative value ${blockNumber}`)
-
-    const blockNumberInHex = utils.hexValue(blockNumber)
-    const key = `${this.connectedNetwork.chainId}getBlockStats(${blockNumberInHex})`
-    const result = await this.cachedExecutor<BlockStats>(key, () => this.send('internal_getBlockStats', [blockNumberInHex]))
-    return EthereumApiFormatters.FormatBlockStats(result)
-  }
-
   public async getBlockWithTransactions(blockNumber: number): Promise<BlockWithTransactions> {
     const blockNumberInHex = utils.hexValue(blockNumber)
-    const key = `${this.connectedNetwork.chainId}getBlock(${blockNumber})`
+    const key = `${this.connectedNetwork.chainId}getBlockWithTransactions(${blockNumber})`
     const result = await this.cachedExecutor<BlockWithTransactions>(key, () => this.send('eth_getBlockByNumber', [blockNumberInHex, true]))
     return EthereumApiFormatters.FormatBlockWithTransactions(result)
   }
@@ -81,5 +49,21 @@ export class EthereumApi extends WebSocketProvider<EthereumWebSocketEventMap> {
     const key = `${this.connectedNetwork.chainId}getTransaction(${hash})`
     const result = await this.cachedExecutor<Transaction>(key, () => this.send('eth_getTransactionByHash', [hash]))
     return EthereumApiFormatters.FormatTransaction(result);
+  }
+
+  public async getBlockStats(blockNumber: number): Promise<BlockStats | undefined> {
+    if (blockNumber < 0)
+      throw Error(`Invalid block of negative value ${blockNumber}`)
+
+    const blockNumberInHex = utils.hexValue(blockNumber)
+    const key = `${this.connectedNetwork.chainId}getBlockStats(${blockNumberInHex})`
+    const result = await this.cachedExecutor<BlockStats>(key, () => this.send('internal_getBlockStats', [blockNumberInHex]))
+    return EthereumApiFormatters.FormatBlockStats(result)
+  }
+
+  public async getInitialData(): Promise<InitialData> {
+    const key = `${this.connectedNetwork.chainId}getInitialData()`
+    const result = await this.cachedExecutor<InitialData>(key, () => this.send('internal_getInitialData', []))
+    return EthereumApiFormatters.FormatInitialData(result);
   }
 }

--- a/frontend/src/libs/ethereum/ethereum-types.ts
+++ b/frontend/src/libs/ethereum/ethereum-types.ts
@@ -74,4 +74,11 @@ export interface Transaction {
 export interface Totals {
   burned: BigNumber
   tipped: BigNumber
+  issuance: BigNumber
+}
+
+export interface Data {
+  blockStats: BlockStats
+  clients: number
+  totals: Totals
 }

--- a/frontend/src/libs/ethereum/ethereum-types.ts
+++ b/frontend/src/libs/ethereum/ethereum-types.ts
@@ -77,8 +77,15 @@ export interface Totals {
   issuance: BigNumber
 }
 
-export interface Data {
-  blockStats: BlockStats
+export interface InitialData {
+  blockNumber: number
+  blocks: BlockStats[]
+  clients: number
+  totals: Totals
+}
+
+export interface BlockData {
+  block: BlockStats
   clients: number
   totals: Totals
 }

--- a/frontend/src/pages/BlockDetail.tsx
+++ b/frontend/src/pages/BlockDetail.tsx
@@ -32,7 +32,6 @@ import { Loader } from "../organisms/Loader";
 import { useEthereum } from "../contexts/EthereumContext";
 import { Card } from "../atoms/Card";
 import {
-  BlockExplorerApi,
   BurnedBlockTransaction,
 } from "../contexts/BlockExplorerContext";
 import { FirePit } from "../atoms/FirePit";
@@ -60,8 +59,8 @@ export function EthBlockDetail() {
       if (!eth || !id) return;
       const blockNumber = parseInt(id);
       
-      const blockTransactions = await eth.getBlockWithTransactions(blockNumber);
-      if (!blockTransactions) {
+      const blockTransaction = await eth.getBlockWithTransactions(blockNumber);
+      if (!blockTransaction) {
         setState({
           block: undefined,
           transactions: undefined,
@@ -71,10 +70,14 @@ export function EthBlockDetail() {
         return
       }
 
-      const block = await BlockExplorerApi.fetchBlock(eth, blockNumber);
+      const stats = await eth.getBlockStats(blockTransaction.number);
+
       setState({
-        block: block,
-        transactions: blockTransactions.transactions,
+        block: {
+          ...blockTransaction,
+          stats: stats
+        },
+        transactions: blockTransaction.transactions,
         onBeforeRender: blockNumber > 0,
         onAfterRender: true,
       });

--- a/frontend/src/pages/Dashboard/CardCountdown.tsx
+++ b/frontend/src/pages/Dashboard/CardCountdown.tsx
@@ -17,9 +17,11 @@ export function CardCountdown({ genesisBlock, currentBlock }: { genesisBlock: nu
     if (!eth)
       return;
     const run = async () => {
-      const current = await eth.getBlock(currentBlock);
-      const previous = await eth.getBlock(currentBlock - numberOfBlocksToLookback);
-      setTimePerBlockInMs(((current.timestamp - previous.timestamp) * 1000) / numberOfBlocksToLookback);
+      const current = await eth.getBlockStats(currentBlock);
+      const previous = await eth.getBlockStats(currentBlock - numberOfBlocksToLookback);
+      if (current && previous) {
+        setTimePerBlockInMs(((current.timestamp - previous.timestamp) * 1000) / numberOfBlocksToLookback);
+      }
     };
 
     run();

--- a/frontend/src/pages/Dashboard/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard/Dashboard.tsx
@@ -52,7 +52,7 @@ function DashboardLayout({ children }: { children: React.ReactNode; }) {
 }
 
 export function Dashboard() {
-  const { details, session, blocks, clients } = useBlockExplorer();
+  const { details, session, blocks } = useBlockExplorer();
   const { eth } = useEthereum();
   const { isMobile } = useMobileDetector();
 
@@ -71,9 +71,9 @@ export function Dashboard() {
         <CardDonate type={CardDonateType.TopSideBar} />
         {!activated && <CardCountdown genesisBlock={eth.connectedNetwork.genesis} currentBlock={latestBlock} />}
         {activated && <CardLiveChart blocks={blocks} />}
-        <CardTotalBurned totalBurned={details.totalBurned} amount={amount} />
+        <CardTotalBurned totalBurned={details.totals.burned} amount={amount} />
         <CardCurrentSession session={session} amount={amount} />
-        <CardLatestStats details={details} clients={clients} />
+        <CardLatestStats details={details} clients={details.clients} />
         <CardBlocks activated={activated} />
         <CardDonate type={CardDonateType.BottomSideBar}/>
       </DashboardLayout>
@@ -85,9 +85,9 @@ export function Dashboard() {
       <Flex flex={1} direction="row" gridGap={layoutConfig.gap}>
         <Flex direction="column" w={300} flexShrink={0} gridGap={layoutConfig.gap}>
           <CardDonate type={CardDonateType.TopSideBar} />
-          <CardTotalBurned totalBurned={details.totalBurned} amount={amount} />
+          <CardTotalBurned totalBurned={details.totals.burned} amount={amount} />
           <CardCurrentSession session={session} amount={amount} />
-          <CardLatestStats details={details} clients={clients} />
+          <CardLatestStats details={details} clients={details.clients} />
           <CardDonate type={CardDonateType.BottomSideBar}/>
         </Flex>
         <Flex direction="column" flex={1} gridGap={layoutConfig.gap}>

--- a/watchtheburn.code-workspace
+++ b/watchtheburn.code-workspace
@@ -17,6 +17,7 @@
 		}
 	],
 	"settings": {
-		"files.insertFinalNewline": true
+		"files.insertFinalNewline": true,
+		"editor.renderWhitespace": "all"
 	}
 }


### PR DESCRIPTION
- Introduces to `internal_getIntialData` so that we can get everything we need at one websocket connect.
- Introduces a new socket event for `data` to get all the data in one go instead of querying multiple times per block
- Caches the last 50 blocks seen to use for initial data
- Deprecates `internal_getTotals`, `eth_blockNumber`, and `eth_chainId` 
- Makes `getTotals` typed
