### PR TITLE
temporarily disable animations

### DIFF
--- a/frontend/src/pages/Dashboard/CardBlocks.tsx
+++ b/frontend/src/pages/Dashboard/CardBlocks.tsx
@@ -13,6 +13,8 @@ import { Loader } from "../../organisms/Loader";
 import { timeSince } from "../../utils/time";
 import { BlockStats } from "../../libs/ethereum";
 
+const enableAnimation = false;
+
 function GasUsedInfo() {
   return (
     <Box p={4}>
@@ -37,7 +39,7 @@ function BlockItem({ activated, block }: { activated: boolean, block: BlockStats
           {block.number}
         </Link>
       </TdPlus>
-      <TdPlus><VStack alignItems="flex-end"><HStack><BigNumberText number={block.burned} /><FirePit size="12px" /></HStack></VStack></TdPlus>
+      <TdPlus><VStack alignItems="flex-end"><HStack><BigNumberText number={block.burned} />{enableAnimation && <FirePit size="12px" />}</HStack></VStack></TdPlus>
       <TdPlus textAlign="right"><BigNumberText number={block.tips} /></TdPlus>
       <TdPlus textAlign="right"><BigNumberText number={block.baseFee} /></TdPlus>
       <TdPlus textAlign="right"><VStack alignItems="flex-end"><HStack><GasTarget gasTarget={block.gasTarget} /></HStack></VStack></TdPlus>
@@ -77,12 +79,7 @@ export function BlockList({ activated }: { activated: boolean; }) {
           </Tr>
         </Thead>
         <Tbody>
-          <Tr>
-            <TdPlus textAlign="left">{details.currentBlock + 1}</TdPlus>
-            <TdPlus colSpan={9}>
-              <BlockProgress />
-            </TdPlus>
-          </Tr>
+	  {enableAnimation && <Tr><TdPlus textAlign="left">{details.currentBlock + 1}</TdPlus><TdPlus colSpan={9}><BlockProgress /></TdPlus></Tr>}
           {blocks.map((block, idx) => (
             <BlockItem
               key={idx}

--- a/frontend/src/pages/Dashboard/CardLatestStats.tsx
+++ b/frontend/src/pages/Dashboard/CardLatestStats.tsx
@@ -6,6 +6,8 @@ import { Card } from "../../atoms/Card";
 import { BigNumberText } from "../../organisms/BigNumberText";
 import { FirePit } from "../../atoms/FirePit";
 
+const enableAnimation = false;
+
 export function CardLatestStats({ details, clients }: { details: BlockExplorerDetails; clients: number | undefined }) {
   const [count, setCount] = useState<number | undefined>(clients);
 
@@ -26,7 +28,7 @@ export function CardLatestStats({ details, clients }: { details: BlockExplorerDe
         <BigNumberText number={details.currentBaseFee} fontSize={16} textAlign="right" />
       </HStack>
       <HStack>
-        <HStack flex={1}><Text>Watching the Burn</Text> <FirePit size="12px" /></HStack>
+        <HStack flex={1}><Text>Watching the Burn</Text>{enableAnimation && <FirePit size="12px" />}</HStack>
         {count === undefined && <Text>calculating ...</Text>}
         {count !== undefined && <Text>{count} users</Text>}
       </HStack>

--- a/frontend/src/templates/Layout.tsx
+++ b/frontend/src/templates/Layout.tsx
@@ -13,6 +13,8 @@ import { EthereumNetworkBadge } from "../organisms/Network";
 import { layoutConfig } from "../layoutConfig";
 import { Announcement } from "../organisms/Announcement";
 
+const enableAnimation = false;
+
 interface LayoutProps {
   children: React.ReactNode;
   direction: CSS.Property.FlexDirection;
@@ -44,7 +46,7 @@ export function Layout(props: LayoutProps) {
             }}
           >
             <HStack cursor="pointer">
-              <FirePit sparkCount={12} size="24px" />
+              {enableAnimation && <FirePit sparkCount={12} size="24px" />}
               <Heading size="lg" color="white">Watch The <Box display="inline" color="brand.orange">Burn</Box></Heading>
             </HStack>
           </Link>


### PR DESCRIPTION
Right now, fire and line animations consume significant cpu time. We should disable until fixed.