### PR TITLE
Implement worker based transaction receipts fetching

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,10 +18,7 @@
             "mode": "auto",
             "program": "${workspaceFolder}/daemon",
             "args": [
-                "--geth-endpoint-http=http://localhost:8557",
-                "--geth-endpoint-websocket=ws://localhost:8556",
-                "--db-path=${workspaceFolder}/watchtheburn.db",
-                "--development",
+                "--db-path=${workspaceFolder}/watchtheburn.db"
             ]
         }
     ]

--- a/daemon/cmd/root.go
+++ b/daemon/cmd/root.go
@@ -49,9 +49,9 @@ func newRootCmd() *cobra.Command {
 	}
 
 	rootCmd.Flags().StringVar(&addr, "addr", ":8080", "HTTP service address")
-	rootCmd.Flags().BoolVar(&development, "development", false, "enable for development mode")
-	rootCmd.Flags().StringVar(&gethEndpointHTTP, "geth-endpoint-http", "", "Endpoint to geth for http")
-	rootCmd.Flags().StringVar(&gethEndpointWebsocket, "geth-endpoint-websocket", "", "Endpoint to geth for websocket")
+	rootCmd.Flags().BoolVar(&development, "development", true, "enable for development mode")
+	rootCmd.Flags().StringVar(&gethEndpointHTTP, "geth-endpoint-http", "http://localhost:8545", "Endpoint to geth for http")
+	rootCmd.Flags().StringVar(&gethEndpointWebsocket, "geth-endpoint-websocket", "ws://localhost:8546", "Endpoint to geth for websocket")
 	rootCmd.Flags().StringVar(&dbPath, "db-path", "watchtheburn.db", "Path to the SQLite db")
 	rootCmd.Flags().BoolVar(&ropsten, "ropsten", false, "Use ropsten block numbers")
 

--- a/daemon/cmd/root.go
+++ b/daemon/cmd/root.go
@@ -14,6 +14,7 @@ func newRootCmd() *cobra.Command {
 	var gethEndpointWebsocket string
 	var dbPath string
 	var ropsten bool
+	var workerCount int
 
 	rootCmd := &cobra.Command{
 		// TODO:
@@ -44,6 +45,7 @@ func newRootCmd() *cobra.Command {
 				gethEndpointWebsocket,
 				dbPath,
 				ropsten,
+				workerCount,
 			)
 		},
 	}
@@ -53,6 +55,7 @@ func newRootCmd() *cobra.Command {
 	rootCmd.Flags().StringVar(&gethEndpointHTTP, "geth-endpoint-http", "http://localhost:8545", "Endpoint to geth for http")
 	rootCmd.Flags().StringVar(&gethEndpointWebsocket, "geth-endpoint-websocket", "ws://localhost:8546", "Endpoint to geth for websocket")
 	rootCmd.Flags().StringVar(&dbPath, "db-path", "watchtheburn.db", "Path to the SQLite db")
+	rootCmd.Flags().IntVar(&workerCount, "worker-count", 10, "Number of workers to spawn to parallelize http client")
 	rootCmd.Flags().BoolVar(&ropsten, "ropsten", false, "Use ropsten block numbers")
 
 	return rootCmd
@@ -65,6 +68,7 @@ func root(
 	gethEndpointWebsocket string,
 	dbPath string,
 	ropsten bool,
+	workerCount int,
 ) error {
 	hub, err := hub.New(
 		development,
@@ -72,6 +76,7 @@ func root(
 		gethEndpointWebsocket,
 		dbPath,
 		ropsten,
+		workerCount,
 	)
 	if err != nil {
 		return err

--- a/daemon/hub/hub.go
+++ b/daemon/hub/hub.go
@@ -123,7 +123,7 @@ func New(
 	}
 
 	transactionReceiptWorker := &TransactionReceiptWorker{
-		NumWorkers: 10,
+		NumWorkers: 20,
 		Endpoint: gethEndpointHTTP,
 	}
 

--- a/daemon/hub/hub.go
+++ b/daemon/hub/hub.go
@@ -84,6 +84,7 @@ func New(
 	gethEndpointWebsocket string,
 	dbPath string,
 	ropsten bool,
+	workerCount int,
 ) (*Hub, error) {
 	upgrader := &websocket.Upgrader{
 		ReadBufferSize:  1024,
@@ -123,7 +124,7 @@ func New(
 	}
 
 	transactionReceiptWorker := &TransactionReceiptWorker{
-		NumWorkers: 20,
+		NumWorkers: workerCount,
 		Endpoint: gethEndpointHTTP,
 	}
 

--- a/daemon/hub/hub.go
+++ b/daemon/hub/hub.go
@@ -1095,8 +1095,8 @@ func (h *Hub) batchTransactionReceiptJobs(transactions []string, blockNumber uin
 	close(jobs)
 
 	var allPriorityFeePerGasMwei []uint64
-	var blockBurned *big.Int
-	var blockTips *big.Int
+	blockBurned := big.NewInt(0)
+	blockTips := big.NewInt(0)
 
 	for a := 0; a < numJobs; a++ {
 		response := <-results

--- a/daemon/hub/hub.go
+++ b/daemon/hub/hub.go
@@ -1010,7 +1010,7 @@ func (h *Hub) updateBlockStats(blockNumber uint64, updateCache bool) (sql.BlockS
 	var allPriorityFeePerGasMwei []uint64
 
 	// Fetch all transaction receipts to calculate burned, and tips.
-	batchPriorityFee, batchBurned, batchTips := h.batchTransactionReceiptJobs(block.Transactions, blockNumber, baseFee); 
+	batchPriorityFee, batchBurned, batchTips := h.batchTransactionReceiptJobs(block.Transactions, blockNumber, baseFee, updateCache); 
 	allPriorityFeePerGasMwei = append(batchPriorityFee[:], allPriorityFeePerGasMwei[:]...)
 	blockBurned.Add(blockBurned, batchBurned)
 	blockTips.Add(blockTips, batchTips)

--- a/daemon/hub/hub.go
+++ b/daemon/hub/hub.go
@@ -1094,7 +1094,7 @@ func (h *Hub) updateLatestBlock() (uint64, error) {
 	)
 
 	if err != nil {
-		return 0, fmt.Errorf("failed to fetch latest block number from geth")
+		return 0, fmt.Errorf("failed to fetch latest block number from geth: %v", err)
 	}
 
 	var hexBlockNumber string

--- a/daemon/hub/transactionreceiptworker.go
+++ b/daemon/hub/transactionreceiptworker.go
@@ -1,0 +1,151 @@
+package hub
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"strconv"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+type TransactionReceiptWorker struct {
+	NumWorkers int
+	Endpoint   string
+
+	jobs       chan transactionReceiptJob
+	rpcClient  *RPCClient
+}
+
+func (h *TransactionReceiptWorker) Initialize() {
+	h.rpcClient = &RPCClient{
+		endpoint:   h.Endpoint,
+		httpClient: new(http.Client),
+	}
+
+	h.jobs = make(chan transactionReceiptJob)
+
+	for w := 1; w <= h.NumWorkers; w++ {
+		go h.startWorker(w, h.jobs)
+	}
+}
+
+func (h *TransactionReceiptWorker) QueueJob(transactions []string, blockNumber uint64, baseFee *big.Int, updateCache bool) ([]uint64, *big.Int, *big.Int) {
+	results := make(chan transactionReceiptResult, len(transactions))
+
+	for _, tHash := range transactions {
+		h.jobs <- transactionReceiptJob{
+			Results:         results,
+			BlockNumber:     blockNumber,
+			TransactionHash: tHash,
+			BaseFee:         baseFee,
+			UpdateCache:     updateCache,
+		}
+	}
+
+	var allPriorityFeePerGasMwei []uint64
+	blockBurned := big.NewInt(0)
+	blockTips := big.NewInt(0)
+
+	for a := 0; a < len(transactions); a++ {
+		response := <-results
+
+		if response.Error != nil {
+			log.Errorln(response.Error)
+			continue
+		}
+
+		if response.Result == nil {
+			continue
+		}
+
+		allPriorityFeePerGasMwei = append(allPriorityFeePerGasMwei, response.Result.PriorityFeePerGas.Uint64())
+		blockBurned.Add(blockBurned, response.Result.Burned)
+		blockTips.Add(blockTips, response.Result.Tips)
+	}
+
+	return allPriorityFeePerGasMwei, blockBurned, blockTips
+}
+
+func (h *TransactionReceiptWorker) startWorker(id int, jobs <-chan transactionReceiptJob) {
+	for j := range jobs {
+		response, err := h.processTransactionReceipt(j)
+		j.Results <- transactionReceiptResult{Result: response, Error: err}
+	}
+}
+
+func (h *TransactionReceiptWorker) processTransactionReceipt(param transactionReceiptJob) (*transactionReceiptResponse, error) {
+	raw, err := h.rpcClient.CallContext(
+		"2.0",
+		"eth_getTransactionReceipt",
+		strconv.Itoa(int(param.BlockNumber)),
+		param.UpdateCache,
+		param.TransactionHash,
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("error getting transaction receipt: %v", err)
+	}
+
+	receipt := TransactionReceipt{}
+	err = json.Unmarshal(raw, &receipt)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling transaction receipt: %v", err)
+	}
+
+	if receipt.BlockNumber == "" {
+		log.Warnf("block %d, transaction %s: found empty transaction receipt", param.BlockNumber, param.TransactionHash)
+		return nil, nil
+	}
+
+	gasUsed, err := hexutil.DecodeBig(receipt.GasUsed)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding gas used: %v", err)
+	}
+
+	effectiveGasPrice := big.NewInt(0)
+
+	if receipt.EffectiveGasPrice != "" {
+		effectiveGasPrice, err = hexutil.DecodeBig(receipt.EffectiveGasPrice)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding effective gas price: %v", err)
+		}
+	}
+
+	burned := big.NewInt(0)
+	burned.Mul(gasUsed, param.BaseFee)
+
+	tips := big.NewInt(0)
+	tips.Mul(gasUsed, effectiveGasPrice)
+	tips.Sub(tips, burned)
+
+	priorityFeePerGas := big.NewInt(0)
+	priorityFeePerGas.Div(tips, gasUsed)
+	priorityFeePerGasMwei := priorityFeePerGas.Div(priorityFeePerGas, big.NewInt(1_000_000))
+
+	return &transactionReceiptResponse{
+		Burned:            burned,
+		Tips:              tips,
+		PriorityFeePerGas: priorityFeePerGasMwei,
+	}, nil
+}
+
+type transactionReceiptJob struct {
+	Results         chan transactionReceiptResult
+	TransactionHash string
+	BlockNumber     uint64
+	BaseFee         *big.Int
+	UpdateCache     bool
+}
+
+type transactionReceiptResponse struct {
+	Burned            *big.Int
+	Tips              *big.Int
+	PriorityFeePerGas *big.Int
+}
+
+type transactionReceiptResult struct {
+	Result *transactionReceiptResponse
+	Error  error
+}

--- a/daemon/hub/transactionreceiptworker.go
+++ b/daemon/hub/transactionreceiptworker.go
@@ -67,6 +67,7 @@ func (h *TransactionReceiptWorker) startWorker(id int, jobs <-chan transactionRe
 		endpoint:   h.Endpoint,
 		httpClient: new(http.Client),
 	}
+	log.Infof("worker %d started", id)
 
 	for j := range jobs {
 		response, err := h.processTransactionReceipt(rpcClient, j)

--- a/daemon/hub/transactionreceiptworker.go
+++ b/daemon/hub/transactionreceiptworker.go
@@ -63,9 +63,11 @@ func (h *TransactionReceiptWorker) QueueJob(transactions []string, blockNumber u
 }
 
 func (h *TransactionReceiptWorker) startWorker(id int, jobs <-chan transactionReceiptJob) {
+	tr := &http.Transport{}
+	client := &http.Client{Transport: tr}
 	rpcClient := &RPCClient{
 		endpoint:   h.Endpoint,
-		httpClient: new(http.Client),
+		httpClient: client,
 	}
 	log.Infof("worker %d started", id)
 


### PR DESCRIPTION
This will improve parallelzation of calling transaction receipts
instead of doing it sequentially. Uses a worker pool with jobs

#58 