### PR TITLE
Fix bug where socket client reconnects doesn't subscribe

### DIFF
--- a/frontend/src/contexts/EthereumContext.tsx
+++ b/frontend/src/contexts/EthereumContext.tsx
@@ -49,9 +49,6 @@ const EthereumProvider = ({
         return false
       }
     
-      ethereum.off('retrySuccess', onRetryCheckStatus)
-      ethereum.off('retryMaxAttemptsReached', onRetryMaxAttemptsReached)
-
       await ethereum.subscribeToChannels();
 
       setEth(ethereum)


### PR DESCRIPTION
The Context wasn't running again when a reconect happened cause we turned off the listeners.