### PR TITLE
Race Condition - Fix USD Watcher to be around mutex

### DIFF
--- a/daemon/hub/hub.go
+++ b/daemon/hub/hub.go
@@ -230,7 +230,7 @@ func (h *Hub) initializeGrpcWebSocket(gethEndpointWebsocket string) error {
 						TotalsMonth: totalsMonth,
 						TotalsWeek:  totalsWeek,
 						Version:     version.Version,
-						USDPrice:    h.usd.Price,
+						USDPrice:    h.usd.GetPrice(),
 					},
 					"aggregatesData": &AggregatesData{
 						TotalsPerDay:   h.s.totalsPerDay.getTotals(1),
@@ -549,7 +549,7 @@ func (h *Hub) handleInitialData() func(c *Client, message jsonrpcMessage) (json.
 			TotalsMonth: totalsMonth,
 			TotalsWeek:  totalsWeek,
 			Version:     version.Version,
-			USDPrice:    h.usd.Price,
+			USDPrice:    h.usd.GetPrice(),
 		}
 
 		dataJSON, err := json.Marshal(data)


### PR DESCRIPTION
Running --race showed this dump

```
WARNING: DATA RACE
Read at 0x00c00021ab18 by goroutine 230:
  github.com/mohamedmansour/ethereum-burn-stats/daemon/hub.(*Hub).handleInitialData.func1()
        /go/src/github.com/mohamedmansour/ethereum-burn-stats/daemon/hub/hub.go:552
	+0xfd8

Previous write at 0x00c00021ab18 by goroutine 85:
  github.com/mohamedmansour/ethereum-burn-stats/daemon/hub.(*USDPriceWatcher).refreshCoinbasePrice()
        /go/src/github.com/mohamedmansour/ethereum-burn-stats/daemon/hub/usdpricewatcher.go:48
	+0x4bc
```